### PR TITLE
fix: redirect directory missing trailing slash

### DIFF
--- a/src/handlers/unixfs-dir.js
+++ b/src/handlers/unixfs-dir.js
@@ -50,6 +50,28 @@ export async function handleUnixfsDir (request, env, ctx) {
   if (!entry.type.includes('directory')) throw new Error('non UnixFS directory entry')
   if (!unixfs) throw new Error('missing UnixFS service')
 
+  const headers = {
+    'Content-Type': 'text/html',
+    Etag: `"DirIndex-gateway-lib@2.0.3_CID-${entry.cid}"`
+  }
+
+  if (request.method === 'HEAD') {
+    return new Response(null, { headers })
+  }
+  if (request.method !== 'GET') {
+    throw new HttpError('method not allowed', { status: 405 })
+  }
+
+  const url = new URL(request.url)
+
+  // redirect directory missing trailing slash
+  if (!url.pathname.endsWith('/')) {
+    return new Response(null, {
+      status: 301,
+      headers: { Location: `${url.pathname}/${url.search}` }
+    })
+  }
+
   // serve index.html if directory contains one
   try {
     const indexPath = `${dataCid}${path}${path.endsWith('/') ? '' : '/'}index.html`
@@ -60,19 +82,7 @@ export async function handleUnixfsDir (request, env, ctx) {
     if (err.code !== 'ERR_NOT_FOUND') throw err
   }
 
-  const headers = {
-    'Content-Type': 'text/html',
-    Etag: `"DirIndex-gateway-lib@2.0.2_CID-${entry.cid}"`
-  }
-
-  if (request.method === 'HEAD') {
-    return new Response(null, { headers })
-  }
-  if (request.method !== 'GET') {
-    throw new HttpError('method not allowed', { status: 405 })
-  }
-
-  const isSubdomain = new URL(request.url).hostname.includes('.ipfs.')
+  const isSubdomain = url.hostname.includes('.ipfs.')
   /** @param {string} p CID path like "<cid>[/optional/path]" */
   const entryPath = p => isSubdomain ? p.split('/').slice(1).join('/') : `/ipfs/${p}`
 

--- a/test/handlers/unixfs-dir.spec.js
+++ b/test/handlers/unixfs-dir.spec.js
@@ -26,9 +26,34 @@ describe('UnixFS directory handler', () => {
     const dagula = new Dagula(blockstore)
     const ctx = { waitUntil, unixfs: dagula, dataCid: dirBlock.cid, path, searchParams }
     const env = { DEBUG: 'true' }
-    const req = new Request('http://localhost/ipfs/bafy')
+    const req = new Request('http://localhost/ipfs/bafy/')
     const res = await handleUnixfs(req, env, ctx)
     const html = await res.text()
     assert(html.includes('Puzzle%20People%20%231.png'))
+  })
+
+  it('redirects missing trailing slash', async () => {
+    const waitUntil = mockWaitUntil()
+    const path = '/test'
+    const searchParams = new URLSearchParams()
+    const fileBlock = await encode({ value: fromString('test'), codec: raw, hasher })
+    const dirData = pb.createNode(new UnixFS({ type: 'directory' }).marshal(), [{
+      Name: 'Puzzle People #1.png',
+      Hash: fileBlock.cid
+    }])
+    const dirBlock = await encode({ value: dirData, codec: pb, hasher })
+    const rootDirData = pb.createNode(new UnixFS({ type: 'directory' }).marshal(), [{
+      Name: 'test',
+      Hash: dirBlock.cid
+    }])
+    const rootDirBlock = await encode({ value: rootDirData, codec: pb, hasher })
+    const blockstore = mockBlockstore([rootDirBlock, dirBlock, fileBlock])
+    const dagula = new Dagula(blockstore)
+    const ctx = { waitUntil, unixfs: dagula, dataCid: rootDirBlock.cid, path, searchParams }
+    const env = { DEBUG: 'true' }
+    const req = new Request('http://localhost/ipfs/bafy/test')
+    const res = await handleUnixfs(req, env, ctx)
+    assert.equal(res.status, 301)
+    assert.equal(res.headers.get('location'), '/ipfs/bafy/test/')
   })
 })


### PR DESCRIPTION
Fixes an issue where UnixFS directories missing trailing slashes were not being redirected.

fixes https://github.com/storacha/w3up/issues/1615

Bonus - fixes an issue where the directory contents would be rendered in response to a HEAD request.