### PR TITLE
feat: support `dag-json` and `dag-cbor` preview rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "5.1.3",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
+        "@gct256/hexdump": "^0.1.2",
         "@httpland/range-parser": "^1.2.0",
         "@ipld/car": "^5.2.6",
+        "@ipld/dag-cbor": "^9.2.5",
+        "@ipld/dag-json": "^10.2.5",
         "@web3-storage/handlebars": "^1.0.0",
         "bytes": "^3.1.2",
         "chardet": "^2.0.0",
@@ -23,13 +26,12 @@
         "uint8arrays": "^5.0.1"
       },
       "devDependencies": {
-        "@ipld/dag-cbor": "^9.0.8",
         "@ipld/dag-pb": "^4.0.8",
         "@types/bytes": "^3.1.4",
         "ipfs-unixfs": "^11.1.2",
         "ipfs-unixfs-exporter": "^13.3.0",
         "standard": "^17.1.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -98,11 +100,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.6.tgz",
       "integrity": "sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ=="
-    },
-    "node_modules/@achingbrain/nat-port-mapper/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/@achingbrain/nat-port-mapper/node_modules/uint8-varint": {
       "version": "2.0.4",
@@ -360,6 +357,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@gct256/hexdump": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gct256/hexdump/-/hexdump-0.1.2.tgz",
+      "integrity": "sha512-2ffonPjag1lg7h5rggdNTmfOfRs5fRYw1WIKqR4KmaRVk4L6O7WSInOLC2k2VnHGpq00JXGB6BtZkztxL9YyDg==",
+      "license": "MIT"
+    },
     "node_modules/@handlebars/parser": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-1.1.0.tgz",
@@ -423,12 +426,13 @@
       }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.8.tgz",
-      "integrity": "sha512-ETWJ7p7lmGw5X+BuI/7rf4/k56xyOvAOVNUVuQmnGYBdJjObLPgS+vyFxRk4odATlkyZqCq2MLNY52bhE6SlRA==",
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.5.tgz",
+      "integrity": "sha512-84wSr4jv30biui7endhobYhXBQzQE4c/wdoWlFrKcfiwH+ofaPg8fwsM8okX9cOzkkrsAsNdDyH3ou+kiLquwQ==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
-        "multiformats": "^13.0.0"
+        "multiformats": "^13.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -436,12 +440,13 @@
       }
     },
     "node_modules/@ipld/dag-json": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.1.7.tgz",
-      "integrity": "sha512-ipraTPMA40sZAtUYwFvjHeQjReDJXWI8V3lrOeyedKxMb9rOOCS0B7eodRoWM3RIS2qMqtnu1oZr8kP+QJEN0Q==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.5.tgz",
+      "integrity": "sha512-Q4Fr3IBDEN8gkpgNefynJ4U/ZO5Kwr7WSUMBDbZx0c37t0+IwQCTM9yJh8l5L4SRFjm31MuHwniZ/kM+P7GQ3Q==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "cborg": "^4.0.0",
-        "multiformats": "^13.0.0"
+        "multiformats": "^13.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1330,11 +1335,6 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
-      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/@libp2p/interface/node_modules/uint8-varint": {
       "version": "2.0.4",
@@ -6040,9 +6040,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiformats": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.0.1.tgz",
-      "integrity": "sha512-bt3R5iXe2O8xpp3wkmQhC73b/lC4S2ihU8Dndwcsysqbydqb8N+bpP116qMcClZ17g58iSIwtXUTcg2zT4sniA=="
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.0.tgz",
+      "integrity": "sha512-Mkb/QcclrJxKC+vrcIFl297h52QcKh2Az/9A5vbWytbQt4225UWWWmIuSsKksdww9NkIeYcA7DkfftyLuC/JSg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/multipart-byte-range": {
       "version": "2.0.1",
@@ -7407,10 +7408,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -65,8 +65,11 @@
   "author": "Alan Shaw",
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
+    "@gct256/hexdump": "^0.1.2",
     "@httpland/range-parser": "^1.2.0",
     "@ipld/car": "^5.2.6",
+    "@ipld/dag-cbor": "^9.2.5",
+    "@ipld/dag-json": "^10.2.5",
     "@web3-storage/handlebars": "^1.0.0",
     "bytes": "^3.1.2",
     "chardet": "^2.0.0",
@@ -79,13 +82,12 @@
     "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
-    "@ipld/dag-cbor": "^9.0.8",
     "@ipld/dag-pb": "^4.0.8",
     "@types/bytes": "^3.1.4",
     "ipfs-unixfs": "^11.1.2",
     "ipfs-unixfs-exporter": "^13.3.0",
     "standard": "^17.1.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.9.2"
   },
   "publishConfig": {
     "access": "public"

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -3,7 +3,7 @@ import type { UnixFSEntry } from 'ipfs-unixfs-exporter'
 import type { BlockService, DagService, UnixfsService } from 'dagula'
 import type { TimeoutController } from 'timeout-abort-controller'
 
-export {}
+export { TimeoutController }
 
 export interface Environment {
   DEBUG?: string

--- a/src/handlers/block.js
+++ b/src/handlers/block.js
@@ -1,10 +1,22 @@
 /* eslint-env browser */
+/**
+ * @import { Block } from 'dagula'
+ * @import { BlockDecoder } from 'multiformats'
+ * @import { IpfsUrlContext, BlockContext, UnixfsContext, TimeoutController } from '../bindings.js'
+ */
+import * as dagJSON from '@ipld/dag-json'
+import * as dagCBOR from '@ipld/dag-cbor'
+import './templates/bundle.cjs'
 import { MultipartByteRange } from 'multipart-byte-range'
+import { hexdump } from '@gct256/hexdump'
+import { CID } from 'multiformats/cid'
 import { decodeRangeHeader, resolveRange } from '../util/range.js'
 import { HttpError } from '../util/errors.js'
+import { Handlebars, getTemplate, registerHelper } from '../util/handlebars.js'
 
 /**
- * @typedef {import('../bindings.js').IpfsUrlContext & import('../bindings.js').BlockContext & import('../bindings.js').UnixfsContext & { timeoutController?: import('../bindings.js').TimeoutControllerContext['timeoutController'] }} BlockHandlerContext
+ * @typedef {IpfsUrlContext & BlockContext & UnixfsContext & { timeoutController?: TimeoutController }} BlockHandlerContext
+ * @typedef {IpfsUrlContext & { gatewayDomain?: string, block: Block }} BlockHtmlHandlerContext
  */
 
 /** @type {import('../bindings.js').Handler<BlockHandlerContext>} */
@@ -124,4 +136,117 @@ const handleMultipartRange = async (blocks, cid, ranges, options) => {
     contentType: 'application/vnd.ipld.raw'
   })
   return new Response(source, { status: 206, headers: { ...options?.headers, ...source.headers } })
+}
+
+/** @type {Record<number, BlockDecoder<number, unknown>>} */
+const codecs = {
+  [dagCBOR.code]: dagCBOR,
+  [dagJSON.code]: dagJSON
+}
+
+/** @type {Record<number, string>} */
+const codecNames = {
+  [dagCBOR.code]: 'dag-cbor',
+  [dagJSON.code]: 'dag-json'
+}
+
+/** @param {unknown} obj */
+const isIpldScalar = obj => {
+  switch (typeof obj) {
+    case 'string':
+      return true
+    case 'boolean':
+      return true
+    case 'number':
+      return true
+    case 'object': {
+      if (obj == null) {
+        return true
+      }
+      if (obj instanceof Uint8Array) { // IPLD bytes
+        return true
+      }
+      if (obj instanceof CID) {
+        return true
+      }
+      break
+    }
+  }
+  return false
+}
+registerHelper('isIpldScalar', isIpldScalar)
+
+/** @param {unknown} obj */
+const isIpldList = obj => Array.isArray(obj)
+registerHelper('isIpldList', isIpldList)
+
+/** @param {unknown} obj */
+const isIpldLink = obj => obj instanceof CID
+registerHelper('isIpldLink', isIpldLink)
+
+/** @param {unknown} obj */
+const isIpldMap = obj => {
+  return obj != null && typeof obj == 'object' && !isIpldScalar(obj) && !isIpldList(obj)
+}
+registerHelper('isIpldMap', isIpldMap)
+
+/** @param {unknown} obj */
+const isIpldBytes = obj => obj instanceof Uint8Array
+registerHelper('isIpldBytes', isIpldBytes)
+
+registerHelper('formatIpldScalar', (/** @type {unknown} */ obj) => {
+  switch (typeof obj) {
+    case 'string':
+      return obj
+    case 'boolean':
+      return obj ? 'true' : 'false'
+    case 'number':
+      return obj.toString()
+    case 'object': {
+      if (obj == null) {
+        return 'NULL'
+      }
+      if (obj instanceof Uint8Array) {
+        return hexdump(obj).join('\n')
+      }
+      break
+    }
+  }
+  return 'UNKNOWN'
+})
+
+/** @type {import('../bindings.js').Handler<BlockHtmlHandlerContext>} */
+export async function handleBlockHtml (request, env, ctx) {
+  const { dataCid, path, block } = ctx
+  if (!dataCid) throw new Error('missing data CID')
+  if (path == null) throw new Error('missing URL pathname')
+  if (!block) throw new Error('missing block')
+
+  const codec = codecs[block.cid.code]
+  if (!codec) {
+    throw new HttpError('unsupported entry type', { status: 501 })
+  }
+
+  const headers = {
+    'Content-Type': 'text/html'
+  }
+
+  if (request.method === 'HEAD') {
+    return new Response(null, { headers })
+  }
+  if (request.method !== 'GET') {
+    throw new HttpError('method not allowed', { status: 405 })
+  }
+
+  const isSubdomain = new URL(request.url).hostname.includes('.ipfs.')
+  const html = getTemplate('block')({
+    gatewayDomain: ctx.gatewayDomain || 'storacha.link',
+    path: isSubdomain ? ctx.path : `${ctx.dataCid}/${ctx.path}`,
+    cid: block.cid,
+    codecName: codecNames[block.cid.code] ?? 'UNKNOWN',
+    codecHex: `0x${block.cid.code.toString(16)}`,
+    value: codec.decode(block.bytes)
+  })
+
+  return new Response(html)
 }

--- a/src/handlers/block.js
+++ b/src/handlers/block.js
@@ -12,7 +12,7 @@ import { hexdump } from '@gct256/hexdump'
 import { CID } from 'multiformats/cid'
 import { decodeRangeHeader, resolveRange } from '../util/range.js'
 import { HttpError } from '../util/errors.js'
-import { Handlebars, getTemplate, registerHelper } from '../util/handlebars.js'
+import { getTemplate, registerHelper } from '../util/handlebars.js'
 
 /**
  * @typedef {IpfsUrlContext & BlockContext & UnixfsContext & { timeoutController?: TimeoutController }} BlockHandlerContext
@@ -186,7 +186,7 @@ registerHelper('isIpldLink', isIpldLink)
 
 /** @param {unknown} obj */
 const isIpldMap = obj => {
-  return obj != null && typeof obj == 'object' && !isIpldScalar(obj) && !isIpldList(obj)
+  return obj != null && typeof obj === 'object' && !isIpldScalar(obj) && !isIpldList(obj)
 }
 registerHelper('isIpldMap', isIpldMap)
 

--- a/src/handlers/templates/block.handlebars
+++ b/src/handlers/templates/block.handlebars
@@ -139,26 +139,3 @@
     </div>
   {{/if}}
 {{/inline}}
-
-{{!-- {{ define "value" }}
-  {{ $root := index . 0 }}
-  {{ $value := index . 1 }}
-  {{ if len $value.Values }}
-    <div class="grid dag">
-    {{ range $index, $key := $value.Keys }}
-      {{ template "value" (args $root $key) }}
-      {{ template "value" (args $root (index $value.Values $index)) }}
-    {{ end }}
-    </div>
-  {{ else }}
-    <div translate="no">
-      {{ with $value.CID }}<a class="ipfs-hash" href={{ if $root.DNSLink }}"https://cid.ipfs.tech/#{{ . | urlEscape}}" target="_blank" rel="noreferrer noopener"{{ else }}"{{ $root.GatewayURL }}/ipfs/{{ . | urlEscape}}"{{ end }}>{{ end }}
-        {{ if $value.Long }}
-          <pre>{{- $value.Value -}}</pre>
-        {{ else }}
-          <code class="nowrap">{{- $value.Value -}}</code>
-        {{ end }}
-      {{ with $value.CID }}</a>{{ end }}
-    </div>
-  {{ end }}
-{{ end }} --}}

--- a/src/handlers/templates/block.handlebars
+++ b/src/handlers/templates/block.handlebars
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="description" content="A directory of files hosted on the distributed, decentralized web using IPFS">
+<meta name="description" content="Content-addressed {{codecName}} document hosted on IPFS">
 <meta property="og:title" content="Files on IPFS">
 <meta property="og:description" content="{{path}}">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://bafybeig5nqh5iik5jazmxr7rjhthkbgzcjq6zx4huarbwhz3btzz6cgyty.ipfs.{{gatewayDomain}}/social-card.png">
 <meta name="twitter:title" content="{{path}}">
-<meta name="twitter:description" content="A directory of files hosted on the distributed, decentralized web using IPFS">
+<meta name="twitter:description" content="Content-addressed {{codecName}} document hosted on IPFS">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://bafybeig5nqh5iik5jazmxr7rjhthkbgzcjq6zx4huarbwhz3btzz6cgyty.ipfs.{{gatewayDomain}}/social-card.png">
 <meta name="twitter:creator" content="@ipfs">
@@ -18,6 +18,44 @@
 <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlo89/56ZQ/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUjDu1lo89/6mhTP+zrVP/nplD/5+aRK8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHNiIS6Wjz3/ubFY/761W/+vp1D/urRZ/8vDZf/GvmH/nplD/1BNIm8AAAAAAAAAAAAAAAAAAAAAAAAAAJaPPf+knEj/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf+tpk7/nplD/wAAAAAAAAAAAAAAAJaPPf+2rVX/vrVb/761W/++tVv/vrVb/6+nUP+6tFn/y8Nl/8vDZf/Lw2X/y8Nl/8G6Xv+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/761W/+vp1D/urRZ/8vDZf/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf++tVv/vrVb/761W/++tVv/vbRa/5aPPf+emUP/y8Nl/8vDZf/Lw2X/y8Nl/8vDZf+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/5qTQP+inkb/op5G/6KdRv/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/sqlS/56ZQ//LxWb/0Mlp/9DJaf/Kw2X/oJtE/7+3XP/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf+9tFr/mJE+/7GsUv/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+xrFL/nplD/8vDZf+emUP/AAAAAAAAAACWjz3/op5G/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+inkb/nplD/wAAAAAAAAAAAAAAAKKeRv+3slb/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+1sFX/op5G/wAAAAAAAAAAAAAAAAAAAAAAAAAAop5GUKKeRv/Nxmf/0cpq/9HKav/Rymr/0cpq/83GZ/+inkb/op5GSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G16KeRv/LxWb/y8Vm/6KeRv+inkaPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G/6KeRtcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/n8AAPgfAADwDwAAwAMAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAwAMAAPAPAAD4HwAA/n8AAA==" />
 <title>{{path}}</title>
 <link rel="stylesheet" href="https://bafybeig5nqh5iik5jazmxr7rjhthkbgzcjq6zx4huarbwhz3btzz6cgyty.ipfs.{{gatewayDomain}}/main.css">
+<style>
+.nowrap {
+	white-space: nowrap;
+}
+.grid {
+	display: grid;
+	overflow-x: auto;
+}
+.grid .grid {
+	overflow-x: visible;
+}
+.grid > div {
+	padding: .7em;
+	border-bottom: 1px solid #d9dbe2;
+}
+.grid.dag {
+	grid-template-columns: max-content 1fr;
+}
+.grid.dag pre {
+	margin: 0;
+}
+.grid.dag .grid {
+	padding: 0;
+}
+.grid.dag > div:nth-last-child(-n+2) {
+	border-bottom: 0;
+}
+.grid.dag > div {
+	background: white
+}
+.grid.dag > div:nth-child(4n),
+.grid.dag > div:nth-child(4n+3) {
+	background-color: #f7f8fa;
+}
+.grid.dag > div:nth-of-type(2n+1) {
+	padding-left: 1em;
+}
+</style>
 </head>
 <body>
   <div id="page-header">
@@ -36,36 +74,91 @@
   </div>
   <div id="content">
     <div id="content-header" class="d-flex flex-wrap">
-      <div>
-        <strong>
-          Index of
-          {{#each breadcrumbs~}}
-          /{{#if path}}<a href="{{encodeIPFSPath path}}">{{name}}</a>{{else}}{{name}}{{/if}}
-          {{~else}}
-          {{path}}
-          {{/each}}
-        </strong>
-        {{#if hash}}
-        <div class="ipfs-hash" translate="no">
-          {{hash}}
+      <header>
+        <div>
+          <strong>CID</strong>: <code translate="no">{{cid}}</code>
         </div>
-        {{/if}}
-      </div>
-      {{#if size includeZero=true}}
-      <div class="no-linebreak flex-shrink-1 ml-auto">
-        <strong>&nbsp;{{formatBytes size}}</strong>
-      </div>
-      {{/if}}
+        <div>
+          <strong>Codec</strong>: <code translate="no">{{codecName}} ({{codecHex}})</code>
+        </div>
+      </header>
     </div>
     <div class="table-responsive">
-    <table>
-      <tr>
-        <td class="type-icon">
-          <div class="ipfs-_blank">&nbsp;</div>
-        </td>
-        <td>
-          <a href="{{encodeIPFSPath backLink}}">..</a>
-        </td>
-        <td></td>
-        <td></td>
-      </tr>
+      <table>
+        <tr>
+          <td>
+            <p>You can download this block as:</p>
+            <ul>
+              <li><a href="?format=raw" rel="nofollow">Raw Block</a> (no conversion)</li>
+              {{! No support for re-encoding yet...
+              <li><a href="?format=dag-json" rel="nofollow">Valid DAG-JSON</a> (specs at <a href="https://ipld.io/specs/codecs/dag-json/spec/" target="_blank" rel="noopener noreferrer">IPLD</a> and <a href="https://www.iana.org/assignments/media-types/application/vnd.ipld.dag-json" target="_blank" rel="noopener noreferrer">IANA</a>)</li>
+              <li><a href="?format=dag-cbor" rel="nofollow">Valid DAG-CBOR</a> (specs at <a href="https://ipld.io/specs/codecs/dag-cbor/spec/" target="_blank" rel="noopener noreferrer">IPLD</a> and <a href="https://www.iana.org/assignments/media-types/application/vnd.ipld.dag-cbor" target="_blank" rel="noopener noreferrer">IANA</a>)</li>
+              }}
+            </ul>
+          </td>
+        </tr>
+        <tr style="border-bottom:1px solid #d9dbe2">
+          <td>
+            <strong><span translate="no" style="text-transform: uppercase;">{{codecName}}</span> Preview</strong>
+          </td>
+        </tr>
+        <tr></tr>
+      </table>
+      {{> renderIpldValue value=value }}
+    </div>
+  </div>
+</body>
+</html>
+
+{{#*inline "renderIpldValue" value}}
+  {{#if (isIpldScalar value)}}
+    {{#if (isIpldLink value)}}
+      <div><a style="color:#7f8491" href="https://{{@root.gatewayDomain}}/ipfs/{{value}}"><code class="nowrap">{{value}}</code></a></div>
+    {{else}}
+      {{#if (isIpldBytes value)}}
+        <div><pre style="white-space:pre-line">{{formatIpldScalar value}}</pre></div>
+      {{else}}
+        <div><code class="nowrap">{{formatIpldScalar value}}</code></div>
+      {{/if}}
+    {{/if}}
+  {{/if}}
+  {{#if (isIpldList value)}}
+    <div class="grid dag">
+      {{#each value}}
+        <div><code class="nowrap">{{@index}}</code></div>
+        {{> renderIpldValue value=this}}
+      {{/each}}
+    </div>
+  {{/if}}
+  {{#if (isIpldMap value)}}
+    <div class="grid dag">
+      {{#each value}}
+        <div><code class="nowrap">{{@key}}</code></div>
+        {{> renderIpldValue value=this}}
+      {{/each}}
+    </div>
+  {{/if}}
+{{/inline}}
+
+{{!-- {{ define "value" }}
+  {{ $root := index . 0 }}
+  {{ $value := index . 1 }}
+  {{ if len $value.Values }}
+    <div class="grid dag">
+    {{ range $index, $key := $value.Keys }}
+      {{ template "value" (args $root $key) }}
+      {{ template "value" (args $root (index $value.Values $index)) }}
+    {{ end }}
+    </div>
+  {{ else }}
+    <div translate="no">
+      {{ with $value.CID }}<a class="ipfs-hash" href={{ if $root.DNSLink }}"https://cid.ipfs.tech/#{{ . | urlEscape}}" target="_blank" rel="noreferrer noopener"{{ else }}"{{ $root.GatewayURL }}/ipfs/{{ . | urlEscape}}"{{ end }}>{{ end }}
+        {{ if $value.Long }}
+          <pre>{{- $value.Value -}}</pre>
+        {{ else }}
+          <code class="nowrap">{{- $value.Value -}}</code>
+        {{ end }}
+      {{ with $value.CID }}</a>{{ end }}
+    </div>
+  {{ end }}
+{{ end }} --}}

--- a/src/handlers/templates/unixfs-dir-entries.handlebars
+++ b/src/handlers/templates/unixfs-dir-entries.handlebars
@@ -8,7 +8,7 @@
         </td>
         <td class="no-linebreak">
           {{#if hash}}
-          <a class="ipfs-hash" translate="no" href={{#if @root.dnsLink}}"https://cid.ipfs.io/#{{encodeURIComponent hash}}" target="_blank" rel="noreferrer noopener"{{else}}"/ipfs/{{encodeURIComponent hash}}?filename={{encodeURIComponent name}}"{{/if}}>
+          <a class="ipfs-hash" translate="no" href={{#if @root.dnsLink}}"https://cid.ipfs.tech/#{{encodeURIComponent hash}}" target="_blank" rel="noreferrer noopener"{{else}}"/ipfs/{{encodeURIComponent hash}}?filename={{encodeURIComponent name}}"{{/if}}>
             {{shortHash hash}}
           </a>
           {{/if}}

--- a/src/handlers/unixfs-dir.js
+++ b/src/handlers/unixfs-dir.js
@@ -1,29 +1,18 @@
 /* eslint-env browser */
+/**
+ * @import { UnixfsEntryContext, IpfsUrlContext, UnixfsContext, TimeoutController } from '../bindings.js'
+ */
 import { fromString } from 'uint8arrays/from-string'
-import Handlebars from '@web3-storage/handlebars/runtime.js'
 import bytes from 'bytes'
 import './templates/bundle.cjs'
 import { toReadableStream } from '../util/streams.js'
+import { registerHelper, getTemplate } from '../util/handlebars.js'
 import { handleUnixfsFile } from './unixfs-file.js'
 import { HttpError } from '../util/errors.js'
 
 /**
- * @typedef {import('../bindings.js').UnixfsEntryContext & import('../bindings.js').IpfsUrlContext & import('../bindings.js').UnixfsContext & { timeoutController?: import('../bindings.js').TimeoutControllerContext['timeoutController'] }} UnixfsDirectoryHandlerContext
+ * @typedef {UnixfsEntryContext & IpfsUrlContext & UnixfsContext & { gatewayDomain?: string, timeoutController?: TimeoutController }} UnixfsDirectoryHandlerContext
  */
-
-/**
- * @param {string} name
- * @param {(v: any) => string} fn
- */
-// @ts-ignore missing handlebars types
-const registerHelper = (name, fn) => Handlebars.registerHelper(name, fn)
-
-/**
- * @param {string} name
- * @returns {(data?: any) => string}
- */
-// @ts-ignore missing handlebars types
-const getTemplate = (name) => Handlebars.templates[name]
 
 registerHelper('encodeIPFSPath', (/** @type {string} */ p) => p.split('/').map(s => encodeURIComponent(s)).join('/'))
 registerHelper('encodeURIComponent', encodeURIComponent)
@@ -90,6 +79,7 @@ export async function handleUnixfsDir (request, env, ctx) {
     const parts = entry.path.split('/')
     yield fromString(
       getTemplate('unixfs-dir-header')({
+        gatewayDomain: ctx.gatewayDomain ?? 'storacha.link',
         path: entryPath(entry.path),
         name: entry.name,
         hash: entry.cid.toString(),

--- a/src/handlers/unixfs-dir.js
+++ b/src/handlers/unixfs-dir.js
@@ -79,7 +79,7 @@ export async function handleUnixfsDir (request, env, ctx) {
     const parts = entry.path.split('/')
     yield fromString(
       getTemplate('unixfs-dir-header')({
-        gatewayDomain: ctx.gatewayDomain ?? 'storacha.link',
+        gatewayDomain: ctx.gatewayDomain || 'storacha.link',
         path: entryPath(entry.path),
         name: entry.name,
         hash: entry.cid.toString(),

--- a/src/handlers/unixfs.js
+++ b/src/handlers/unixfs.js
@@ -1,10 +1,18 @@
 /* eslint-env browser */
+/**
+ * @import { IpfsUrlContext, UnixfsContext, TimeoutController } from '../bindings.js'
+ */
+import * as dagJSON from '@ipld/dag-json'
+import * as dagCBOR from '@ipld/dag-cbor'
+import { concat } from 'uint8arrays'
 import { handleUnixfsDir } from './unixfs-dir.js'
 import { handleUnixfsFile } from './unixfs-file.js'
+import { handleBlockHtml } from './block.js'
 import { HttpError } from '../util/errors.js'
+import { collect } from '../util/streams.js'
 
 /**
- * @typedef {import('../bindings.js').IpfsUrlContext & import('../bindings.js').UnixfsContext & { timeoutController?: import('../bindings.js').TimeoutControllerContext['timeoutController'] }} UnixfsHandlerContext
+ * @typedef {IpfsUrlContext & UnixfsContext & { timeoutController?: TimeoutController, gatewayDomain?: string }} UnixfsHandlerContext
  */
 
 /** @type {import('../bindings.js').Handler<UnixfsHandlerContext>} */
@@ -14,7 +22,14 @@ export async function handleUnixfs (request, env, ctx) {
   if (path == null) throw new Error('missing URL pathname')
   if (!unixfs) throw new Error('missing UnixFS context')
 
-  const entry = await unixfs.getUnixfs(`${dataCid}${path}`, { signal: controller?.signal })
+  const options = { signal: controller?.signal }
+  const entry = await unixfs.getUnixfs(`${dataCid}${path}`, options)
+
+  const { cid } = entry
+  if (cid.code == dagCBOR.code || cid.code == dagJSON.code) {
+    const block = { cid, bytes: concat(await collect(entry.content(options))) }
+    return await handleBlockHtml(request, env, { ...ctx, block })
+  }
 
   if (!['file', 'raw', 'directory', 'hamt-directory', 'identity'].includes(entry.type)) {
     throw new HttpError('unsupported entry type', { status: 501 })

--- a/src/handlers/unixfs.js
+++ b/src/handlers/unixfs.js
@@ -26,7 +26,7 @@ export async function handleUnixfs (request, env, ctx) {
   const entry = await unixfs.getUnixfs(`${dataCid}${path}`, options)
 
   const { cid } = entry
-  if (cid.code == dagCBOR.code || cid.code == dagJSON.code) {
+  if (cid.code === dagCBOR.code || cid.code === dagJSON.code) {
     const block = { cid, bytes: concat(await collect(entry.content(options))) }
     return await handleBlockHtml(request, env, { ...ctx, block })
   }

--- a/src/util/handlebars.js
+++ b/src/util/handlebars.js
@@ -1,0 +1,20 @@
+import Handlebars from '@web3-storage/handlebars/runtime.js'
+
+export { Handlebars }
+
+/**
+ * @template T
+ * @template {string|boolean} R
+ * @param {string} name
+ * @param {(v: T) => R} fn
+ */
+// @ts-ignore missing handlebars types
+export const registerHelper = (name, fn) => Handlebars.registerHelper(name, fn)
+
+/**
+ * @template T
+ * @param {string} name
+ * @returns {(data?: T) => string}
+ */
+// @ts-ignore missing handlebars types
+export const getTemplate = (name) => Handlebars.templates[name]

--- a/src/util/streams.js
+++ b/src/util/streams.js
@@ -46,3 +46,15 @@ export function toIterable (readable) {
 
   throw new Error('unknown stream')
 }
+
+/**
+ * @template T
+ * @param {AsyncIterable<T>} source
+ */
+export const collect = async source => {
+  const chunks = []
+  for await (const chunk of source) {
+    chunks.push(chunk)
+  }
+  return chunks
+}


### PR DESCRIPTION
It's a source of confusion that the Storacha gateway redirects to dweb.link for `dag-cbor` and `dag-json` content. This is particularly highlighted when IPNI is down and dweb.link is not able to pull data from our gateway - it appears as though customer data is unavailable. However this is not the case - the data is available over bitswap and via specifying `?format=raw` in the querystring but freeway simply does not know how to render a preview HTML page for the data so it responds with 501, causing the redirect behaviour.

This PR adds a preview HTML page for `dag-cbor` and `dag-json` that is very similar to the HTML page displayed by ipfs.io and dweb.link for these kinds of data.

<img width="1059" height="1006" alt="Screenshot 2025-09-10 at 15 20 42" src="https://github.com/user-attachments/assets/37df783e-69cd-45b8-8028-3bd442c151a7" />

I have also updated a few URLs from ipfs.io to ipfs.tech and added an optional parameter to the handlers allowing the `gatewayDomain` to be set (which ensures resources can be fetched from the same domain as the page is served from).

resolves https://github.com/storacha/gateway-lib/issues/28